### PR TITLE
fix: set static site URL in Astro configuration

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,10 +3,8 @@ import tailwind from "@astrojs/tailwind";
 
 import react from "@astrojs/react";
 
-const site = process.env.DEPLOY_PRIME_URL ?? process.env.URL ?? "https://israelbravo.com";
-
 // https://astro.build/config
 export default defineConfig({
   integrations: [tailwind(), react()],
-  site
+  site: "https://israelbravo.com"
 });


### PR DESCRIPTION
This pull request makes a small configuration update to the Astro project. The change sets the `site` property to a fixed value in `astro.config.mjs`, instead of using environment variables.